### PR TITLE
Parse EOT heredoc type multiline strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ outputs
 .env
 config
 modules
+apps
 dist
 venv
 __pycache__

--- a/terragen/providers/aws/app/utils.py
+++ b/terragen/providers/aws/app/utils.py
@@ -12,6 +12,8 @@ def to_toml(key: str, value):
     """Helper function returns the supplied key/value as valid toml"""
     if isinstance(value, str) and (value.startswith("data.")):
         return f"{key} = {get_env_var(value)}"  # Lookups are variables and shouldn't be quoted
+    elif isinstance(value, str) and value.startswith("<<EOT"):
+        return f"{key} = {value}"
     elif isinstance(value, DictConfig):
         return to_hcl_map(key, value)
     else:

--- a/terragen/providers/aws/tests/app/test_utils.py
+++ b/terragen/providers/aws/tests/app/test_utils.py
@@ -25,6 +25,7 @@ class MockEC2Config:
     associate_public_ip_address: bool = True
     tags: TerraformTags = TerraformTags()
     env_vars: EnvironmentVars = EnvironmentVars()
+    iam_policy: str = '<<EOT\n{\n Version": "2012-10-17",\nEoT'
 
 
 class TestUtils:
@@ -46,3 +47,8 @@ class TestUtils:
     def test_get_env_var_raise_error_if_env_var_not_set(self):
         with pytest.raises(ValueError):
             get_env_var("env.MY_TEST")
+
+    def test_iam_policy_parsed_correctly(self, mock_ec2_config):
+        # IAM Policies need to start with <<EOT to be parsed correctly
+        lookup_value = to_toml("iam_policy", mock_ec2_config.iam_policy)
+        assert lookup_value == 'iam_policy = <<EOT\n{\n Version": "2012-10-17",\nEoT'


### PR DESCRIPTION
Add ability to parse EOT herdoc style strings to allow IAM JSON policy docs to be passed as vars.  

See [Terraform multline docs](https://www.terraform.io/language/expressions/strings#heredoc-strings)